### PR TITLE
[FEAT] Deploy to screambass and verify host-container pub-sub

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ run_container() {
     docker run -it --rm --gpus all \
         -v "$(pwd)/src:/workspaces/src" \
         --network $NETWORK_NAME \
-        -p 9090:9090 \
+        --ipc host \
         --env-file $ENV_FILE \
         $IMAGE_PATH:$IMAGE_TAG \
         /bin/bash -c "export FASTRTPS_DEFAULT_PROFILES_FILE=/humble_ws/fastdds.xml && exec bash" \


### PR DESCRIPTION
- Deployed the project to server `screambass`. Used `clock_test.usd` as a minimal publisher in Isaac Sim on host; Echoing topic inside the Docker container and receives /clock topic messages successfully, confirming host–container connectivity.